### PR TITLE
Enable DXPR license block in config

### DIFF
--- a/config/install/block.block.licenseinfo.yml
+++ b/config/install/block.block.licenseinfo.yml
@@ -1,5 +1,5 @@
 langcode: en
-status: false
+status: true
 dependencies:
   module:
     - dxpr_builder
@@ -8,7 +8,7 @@ dependencies:
     - gin
 id: licenseinfo
 theme: gin
-region: header
+region: pre_content
 weight: 0
 provider: null
 plugin: license_info


### PR DESCRIPTION
Enable DXPR license block in config. Re-rolled for 9.x branch.

Linked issue:
- #1

PR for 10.x:
- #2