### PR TITLE
Remove block visibility rule that was tied to Moderation Sidebar module because the module is removed

### DIFF
--- a/config/install/block.block.dxpr_theme_local_tasks.yml
+++ b/config/install/block.block.dxpr_theme_local_tasks.yml
@@ -18,8 +18,4 @@ settings:
   provider: core
   primary: true
   secondary: true
-visibility:
-  request_path:
-    id: request_path
-    negate: true
-    pages: '/node/*'
+visibility: {  }


### PR DESCRIPTION
Remove block visibility rule that was tied to Moderation Sidebar module because the module is removed