### PR TITLE
Remove call to deprecated function in install hook (#51)

### DIFF
--- a/modules/demo_content/dxpr_marketing_cms_demo_content/dxpr_marketing_cms_demo_content.install
+++ b/modules/demo_content/dxpr_marketing_cms_demo_content/dxpr_marketing_cms_demo_content.install
@@ -3,6 +3,5 @@
 function dxpr_marketing_cms_demo_content_install() {
   // generate themesettings css and color module css
   require_once(\Drupal::service('extension.list.theme')->getPath('dxpr_theme') . '/dxpr_theme_callbacks.inc');
-  dxpr_theme_color_module_css_write('dxpr_theme');
   dxpr_theme_css_cache_build('dxpr_theme');
 }


### PR DESCRIPTION
This PR removes a call to `dxpr_theme_color_module_css_write()` in the install hook. The function has been deprecated in the dxpr_theme version 6.x.

## Linked issues

- #51

## Solution

Remove call to the function in the install hook.

